### PR TITLE
ShuffleUnit

### DIFF
--- a/model.py
+++ b/model.py
@@ -54,7 +54,7 @@ def channel_shuffle(x, groups):
 
 class ShuffleUnit(nn.Module):
     def __init__(self, in_channels, out_channels, groups=3,
-                 grouped_conv=True, depthwise_stride=1):
+                 grouped_conv=True, depthwise_stride=1, combine='add'):
         
         super(ShuffleUnit, self).__init__()
 
@@ -63,6 +63,7 @@ class ShuffleUnit(nn.Module):
         self.grouped_conv = grouped_conv
         self.depthwise_stride = depthwise_stride
         self.groups = groups
+        self.combine = combine
 
         self.bottleneck_channels = self.out_channels // 4
 
@@ -114,11 +115,16 @@ class ShuffleUnit(nn.Module):
             return conv
 
 
-    def _combine(operation):
-        if operation == 'add':
-            pass
-        elif operation == 'concat':
-            pass
+    def _combine(sef, x0, output):
+        """x0 is the initial input. output is the tensor after
+        forward pass.
+        """
+        if self.combine == 'add':
+            # residual connection
+            return x0 + output
+        elif self.combine == 'concat':
+            # concatenate along channel axis
+            return torch.cat((x0, output), 1)
         else:
             raise ValueError("operation \"{}\" not supported.".format(operation))
 

--- a/model.py
+++ b/model.py
@@ -27,6 +27,25 @@ def conv1x1(in_channels, out_channels, groups=1):
         groups=groups,
         stride=1)
 
+def channel_shuffle(x, groups):
+    batchsize, num_channels, height, width = x.data.size()
+
+    channels_per_group = num_channels // groups
+    
+    # reshape
+    x = x.view(batchsize, groups, 
+        channels_per_group, height, width)
+
+    # transpose
+    # - contiguous() required if transpose() is used before view().
+    #   See https://github.com/pytorch/pytorch/issues/764
+    x = torch.transpose(x, 1, 2).contiguous()
+
+    # flatten
+    x = x.view(batchsize, -1, height, width)
+
+    return x
+
 
 class ShuffleUnit(nn.Module):
     def __init__(self, in_channels, out_channels, groups,
@@ -50,6 +69,7 @@ class ShuffleUnit(nn.Module):
             batch_norm=True,
             relu=True
             )
+
 
 
     def _make_grouped_conv1x1(self, in_channels, out_channels,

--- a/tests.py
+++ b/tests.py
@@ -3,7 +3,50 @@ import torch
 import torch.nn as nn
 from torch.autograd import Variable
 import numpy as np
-from model import channel_shuffle
+from model import channel_shuffle, ShuffleNet, ShuffleUnit
+
+# helper methods to make torch Variables based on shape
+def make_variable(shape):
+    return Variable(torch.FloatTensor(np.random.random(shape)))
+
+def get_input(batchsize=1, num_channels=3, height=224, width=224):
+    shape = (batchsize, num_channels, height, width)
+    return make_variable(shape)
+
+class TestShuffleUnit(unittest.TestCase):
+
+    def test_stage3_concat(self):
+        groups, in_channels, out_channels = 3, 240, 480
+        x = get_input(num_channels=in_channels, height=28, width=28)
+
+        unit = ShuffleUnit(
+            in_channels,
+            out_channels,
+            groups=groups,
+            grouped_conv=True,
+            combine='concat'
+            )
+        out = unit.forward(x)
+
+        self.assertEqual(0, np.any(out.data.size() != 
+            (1, in_channels + out_channels, 14, 14)))
+        #print("Passed Stage 3 Concat ShuffleUnit test.")
+
+
+    def test_stage2_add(self):
+        groups, in_channels, out_channels = 3, 240, 240
+        x = get_input(num_channels=in_channels, height=28, width=28)
+        unit = ShuffleUnit(
+            in_channels,
+            out_channels,
+            groups=groups,
+            grouped_conv=True,
+            combine='add'
+            )
+        out = unit.forward(x)
+
+        self.assertEqual(0, np.any(out.data.size() != (1, 240, 28, 28)))
+        #print("Passed Stage 2 Add ShuffleUnit test.")
 
 
 class TestChannelShuffle(unittest.TestCase):
@@ -15,10 +58,8 @@ class TestChannelShuffle(unittest.TestCase):
         width = 2
         groups = 2
         
-        # input shape
-        shape = (batchsize, num_channels, height, width)
-
         # prepare inputs
+        shape = (batchsize, num_channels, height, width)
         tensor = torch.FloatTensor(np.arange(np.product(shape)).reshape(shape))
         x = Variable(tensor)
 
@@ -35,7 +76,7 @@ class TestChannelShuffle(unittest.TestCase):
                            12,  13,
                            14,  15]).reshape(shape)
         self.assertEqual(0, np.any(out != answer))
-        print("Passed channel shuffle test.")
+        #print("Passed channel shuffle test.")
 
 
 if __name__ == "__main__":

--- a/tests.py
+++ b/tests.py
@@ -1,0 +1,42 @@
+import unittest
+import torch
+import torch.nn as nn
+from torch.autograd import Variable
+import numpy as np
+from model import channel_shuffle
+
+
+class TestChannelShuffle(unittest.TestCase):
+    def test(self):
+        
+        batchsize = 1
+        num_channels = 4
+        height = 2
+        width = 2
+        groups = 2
+        
+        # input shape
+        shape = (batchsize, num_channels, height, width)
+
+        # prepare inputs
+        tensor = torch.FloatTensor(np.arange(np.product(shape)).reshape(shape))
+        x = Variable(tensor)
+
+        # run function
+        out = channel_shuffle(x, groups).data.numpy()
+
+        # true answer
+        answer =  np.array([0,   1,
+                            2,   3,
+                            8,   9,
+                           10,  11,
+                            4,   5,
+                            6,   7,
+                           12,  13,
+                           14,  15]).reshape(shape)
+        self.assertEqual(0, np.any(out != answer))
+        print("Passed channel shuffle test.")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
- implemented ShuffleUnit class
- altered calling functions for ShuffleUnit in ShuffleNet class
- added basic unit tests for ShuffleUnit 'concat' and 'add' modes
- cleaned up convolutional helper functions
- refactored ShuffleUnit instantiation in ShuffleNet constructor, now uses OrderedDict of modules with stage names instead of a basic list of layers